### PR TITLE
Backport manual changes of Iuri & Sam

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -15,9 +15,8 @@ data "aws_availability_zones" "available" {
 
 data "aws_ami" "kubernetes_ami" {
   most_recent = true
-  executable_users = ["self"]
   # k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  name_regex = "^k8s-${split(".",${var.k8s_version})[0]}.${split(".",${var.k8s_version})[1]}-debian-jessie-amd64-hvm-ebs.*"
+  name_regex = "^k8s-${element(split(".",var.k8s_version),0)}.${element(split(".",var.k8s_version),1)}-debian-jessie-amd64-hvm-ebs.*"
   owners = ["383156758163"]
 }
 

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -116,6 +116,7 @@ data template_file "cluster-spec" {
     k8s_version           = "${var.k8s_version}"
     vpc_id                = "${data.aws_vpc.vpc_for_k8s.id}"
     vpc_cidr              = "${data.aws_vpc.vpc_for_k8s.cidr_block}"
+    elb_type              = "${var.elb_type}"
     k8s_data_bucket       = "${var.k8s_data_bucket}"
     oidc_issuer_url       = "${var.oidc_issuer_url}"
     etcd_members_main     = "${join("\n",data.template_file.cluster-etcd-member-spec.*.rendered)}"

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -22,6 +22,7 @@ data "aws_availability_zones" "available" {
 # Subnets
 #########################################################
 
+# Private subnets to host the Kubernetes master nodes
 data template_file "master-subnet-spec" {
   count = "3"
   template = "${file("${path.module}/../templates/kops-cluster-subnet.tpl.yaml")}"
@@ -36,19 +37,18 @@ data template_file "master-subnet-spec" {
 }
 
 # Private subnets to host the Kubernetes worker nodes
-# Currently disabled due to https://github.com/kubernetes/kops/issues/1980
-# data template_file "worker-subnet-spec" {
-#   count = "3"
-#   template = "${file("${path.module}/../templates/kops-cluster-subnet.tpl.yaml")}"
+data template_file "worker-subnet-spec" {
+  count = "3"
+  template = "${file("${path.module}/../templates/kops-cluster-subnet.tpl.yaml")}"
 
-#   vars {
-#     name = "element(formatlist("worker-%s", data.aws_availability_zones.available.names)"
-#     type = "Private"
-#     zone = "${element(data.aws_availability_zones.available.names, count.index)}"
-#     id   = ""
-#     cidr = "${cidrsubnet(data.aws_vpc.vpc_for_k8s.cidr_block,8,var.worker_net_number+count.index)}"
-#   }
-# }
+  vars {
+    name = "${element(formatlist("worker-%s", data.aws_availability_zones.available.names), count.index)}"
+    type = "Private"
+    zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+    id   = ""
+    cidr = "${cidrsubnet(data.aws_vpc.vpc_for_k8s.cidr_block,8,var.worker_net_number+count.index)}"
+  }
+}
 
 # Utility subnets are public for ELB creation.
 data template_file "utility-subnet-spec" {
@@ -86,8 +86,7 @@ data template_file "worker-instancegroup-spec" {
   vars {
     name          = "workers"
     cluster-name  = "${var.name}"
-    # TODO Using the master subnets for now. Switch to `worker-%s` when the bug mentioned in the notes at the top is fixed.
-    subnets       = "${join("\n", formatlist("  - master-%s", data.aws_availability_zones.available.names))}"
+    subnets       = "${join("\n", formatlist("  - worker-%s", data.aws_availability_zones.available.names))}"
     instance_type = "${var.worker_instance_type}"
     min           = "${length(data.aws_availability_zones.available.names)}"
     max           = "${var.max_amount_workers}"
@@ -122,10 +121,10 @@ data template_file "cluster-spec" {
     etcd_members_main     = "${join("\n",data.template_file.cluster-etcd-member-spec.*.rendered)}"
     etcd_members_events   = "${join("\n",data.template_file.cluster-etcd-member-spec.*.rendered)}"
     master_subnets        = "${join("\n",data.template_file.master-subnet-spec.*.rendered)}"
-    #worker_subnets          = "${join("\n",data.template_file.worker-subnet-spec.*.rendered)}"
+    worker_subnets        = "${join("\n",data.template_file.worker-subnet-spec.*.rendered)}"
     utility_subnets       = "${join("\n",data.template_file.utility-subnet-spec.*.rendered)}"
     master_instance_group = "${join("\n",data.template_file.master-instancegroup-spec.*.rendered)}"
-    worker_instance_group  = "${data.template_file.worker-instancegroup-spec.rendered}"
+    worker_instance_group = "${data.template_file.worker-instancegroup-spec.rendered}"
   }
 }
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -18,10 +18,9 @@ variable "max_amount_workers" {
 	description = "Maximum amount of workers, minimum will be the amount of AZ"
 }
 
-# Currently disabled due to https://github.com/kubernetes/kops/issues/1980
-# variable "worker_net_number" {
-# 	description = "The network number to start with for worker subnet cidr calculation"
-# }
+variable "worker_net_number" {
+	description = "The network number to start with for worker subnet cidr calculation"
+}
 
 variable "master_instance_type" {
   default = "t2.medium"

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -10,6 +10,11 @@ variable "vpc_id" {
 	description = "Deploy the Kubernetes cluster in this VPC"
 }
 
+variable "elb_type" {
+	description = "Whether to use an Internal or Public ELB in front of the master nodes"
+	default = "Public"
+}
+
 variable "worker_instance_type" {
   default = "t2.medium"
 }

--- a/templates/kops-cluster.tpl.yaml
+++ b/templates/kops-cluster.tpl.yaml
@@ -35,6 +35,7 @@ ${etcd_members_events}
   - 0.0.0.0/0
   subnets:
 ${master_subnets}
+${worker_subnets}
 ${utility_subnets}
   topology:
     dns:

--- a/templates/kops-cluster.tpl.yaml
+++ b/templates/kops-cluster.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
-      type: Internal
+      type: ${elb_type}
       idleTimeoutSeconds: 300
   channel: stable
   cloudProvider: aws

--- a/templates/kops-cluster.tpl.yaml
+++ b/templates/kops-cluster.tpl.yaml
@@ -30,7 +30,7 @@ ${etcd_members_events}
   networkID: ${vpc_id}
   networking:
     calico: {}
-  nonMasqueradeCIDR: 100.65.0.0/10
+  nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0
   subnets:

--- a/templates/kops-instancegroup-master.tpl.yaml
+++ b/templates/kops-instancegroup-master.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
     kops.k8s.io/cluster: ${cluster-name}
   name: ${name}
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: ${kubernetes_ami}
   machineType: ${instance_type}
   maxSize: 1
   minSize: 1

--- a/templates/kops-instancegroup-worker.tpl.yaml
+++ b/templates/kops-instancegroup-worker.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
     kops.k8s.io/cluster: ${cluster-name}
   name: ${name}
 spec:
-  image: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
+  image: ${kubernetes_ami}
   machineType: ${instance_type}
   maxSize: ${max}
   minSize: ${min}


### PR DESCRIPTION
Applying the manual changes of Iuri & Sam to the terraform-kubernetes module.

* Kubernetes ami is searched for based on the `kubernetes_version`
* worker subnets are added now that [kops/1980](https://github.com/kubernetes/kops/issues/1980) is resolved.
* `nonMasqueradeCIDR` fixed to correct value
* Support choosing the ELB type: Public or Internal