### PR TITLE
Create a base module for a base setup after creating a cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # terraform-kubernetes
 
-Terraform module to bootstrap a Kubernetes cluster on AWS using
-[`kops`](https://github.com/kubernetes/kops).
+Terraform modules to bootstrap a Kubernetes cluster on AWS using [`kops`](https://github.com/kubernetes/kops).
 
 ## cluster
-Creates a full `kops` cluster specification yaml, including the required
-instance groups
+
+Creates a full `kops` cluster specification yaml, including the required instance groups
 
 ### Available variables:
  * [`name`]: String(required): base domain name of the cluster. This domain name will be used to lookup a hosted zone on Route53 and as the base for additional DNS records, e.g. for the API ELB.
@@ -26,7 +25,7 @@ instance groups
 ### Example
 ```
 module "kops-aws" {
-  source               = "github.com/skyscrapers/terraform-kubernetes//cluster?ref=937b2c9103dad47a4f292313cf04549217a43bc4"
+  source               = "github.com/skyscrapers/terraform-kubernetes//cluster?ref=0.4.0"
   name                 = "kops.internal.skyscrape.rs"
   k8s_version          = "1.6.4"
   vpc_id               = "${module.customer_vpc.vpc_id}"
@@ -40,14 +39,55 @@ module "kops-aws" {
 }
 ```
 
+## base
+
+Generates a `helm-values.yaml` file to be used to install all the needed helm packages for a base setup of a k8s cluster. It'll also create the needed IAM roles and policies for `external-dns` and `kube2iam`.
+
+This terraform module will add an IAM policy to the k8s cluster nodes roles to allow them to assume other roles in the same AWS account on the path `/kube2iam/`. So if you create a role for a specific deployment in the cluster, make sure you create it on the `/kube2iam/` path.
+
+**Note** that this module must be run **after** there's a running Kubernetes cluster created with the [cluster module](#cluster).
+
+### Available variables:
+
+* [`name`]: String(required): base domain name of the cluster. This domain name will be used to lookup a hosted zone on Route53 and as the base for additional DNS records, e.g. for the API ELB.
+* [`cluster_nodes_iam_role_name`]: String(required): The name of the IAM role of the cluster worker nodes
+* [`nginx_controller_image_version`]: String(optional): The version of the nginx controller docker image
+* [`lego_email`]: String(required): Email address to use for registration with Let's Encrypt
+* [`lego_url`]: String(optional): Let's Encrypt API endpoint. Defaults to `https://acme-staging.api.letsencrypt.org/directory` (staging)
+* [`dex_github_client_id`]: String(required): Client id of the GitHub application for the dex authentication. Must be base64 encoded
+* [`dex_github_client_secret`]: String(required): Client secret of the GitHub application for the kubesignin/dex authentication. Must be base64 encoded
+* [`dex_github_org`]: String(required): GitHub organization for the kubesignin/dex authentication
+* [`kubesignin_client_secret`]: String(required): Secret string for the kubesignin/dex authentication
+
+### Output
+
+* [`external_dns_role_arn`]: String: ARN of the IAM role created for external-dns
+* [`external_dns_role_name`]: String: Name of the IAM role created for external-dns
+
+### Example
+
+```
+module "k8s-base" {
+  source                      = "github.com/skyscrapers/terraform-kubernetes//base?ref=0.4.0"
+  name                        = "kops.internal.skyscrape.rs"
+  cluster_nodes_iam_role_name = "nodes.kops.internal.skyscrape.rs"
+  lego_email                  = "hello@skyscrapers.eu"
+  dex_github_client_id        = "Y2xpZW50X2lkY2xpZW50X2lk"
+  dex_github_client_secret    = "Q2xpZW50U2VjcmV0Q2xpZW50U2VjcmV0Q2xpZW50U2VjcmV0Q2xpZW50U2VjcmV0Q2xpZW50U2VjcmV0"
+  dex_github_org              = "skyscrapers"
+  kubesignin_client_secret    = "something"
+}
+```
+
 ## Usage
 
 ### Bootstrap
+
 First include the generation of the cluster specification to an existing Terraform setup as in the example above. Run Terraform and you will get a file `kops-cluster.yaml` in your current working folder.
 
 If your TF setup was not correct and you need to regenerate the cluster spec and Terraform hints that all resources are up to date, just mark the cluster spec file resource as dirty:
 
-```
+```console
 $ terraform taint -module=kops-aws null_resource.kops_full_cluster-spec_file
 ```
 
@@ -94,6 +134,40 @@ The cluster is configured for Container Network Integration (CNI). After the clu
 
 < @luca, can you add the correct instructions for the network setup here? >
 
+### Deploy base module
+
+Then, in a different terraform stack, deploy the [base module](#base). This will also generate a `helm-values.yaml` file to deploy all the needed helm packages for a base setup.
+
+### Deploy all helm packages
+
+Now that we have the configuration for the different helm packages, we can start deploying them.
+
+First we initialize helm:
+```
+helm init
+```
+
+Then we setup the proper RBAC config for helm:
+```
+kubectl create serviceaccount --namespace kube-system tiller
+kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
+```
+
+Install the Skyscrapers helm repo:
+```
+helm repo add skyscrapers https://skyscrapers.github.io/charts
+```
+
+Install the base helm packages:
+```
+helm install skyscrapers/kube2iam --values helm-values.yaml
+helm install skyscrapers/kube-lego --values helm-values.yaml
+helm install skyscrapers/nginx-ingress --values helm-values.yaml
+helm install skyscrapers/external-dns --values helm-values.yaml
+helm install skyscrapers/kubesignin --values helm-values.yaml
+```
+
 ### Evolve your cluster
 
 If you want to tweak the setup of your cluster, it is quite easy. Note however that while the process is easy, some of the changes could potentially break your cluster.
@@ -125,4 +199,12 @@ Note that the `rolling-update` command also connects to the Kuberenetes API to m
 If you made changes to one of the settings of your core Kuberenetes components (eg API), you will need to force the rolling update, you can use the following command.
 ```
 kops rolling-update cluster kops.internal.skyscrape.rs --instance-group <instance-group-name> --force --yes
+```
+
+#### Helm packages
+
+The same applies to the deployed Helm packages. If an update needs to be made, just taint the `null_resource.helm_values_file` resource in the base module and rerun `terraform apply`. Then with the new `helm-values.yaml` file you'll be able to upgrade all the helm packages by doing:
+
+```
+helm upgrade <release_name> skyscrapers/<helm_chart_name> --values helm-values.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Generates a `helm-values.yaml` file to be used to install all the needed helm pa
 
 This terraform module will add an IAM policy to the k8s cluster nodes roles to allow them to assume other roles in the same AWS account on the path `/kube2iam/`. So if you create a role for a specific deployment in the cluster, make sure you create it on the `/kube2iam/` path.
 
-**Note** that this module must be run **after** there's a running Kubernetes cluster created with the [cluster module](#cluster).
+**Note** that this module must be applied **after** there's a running Kubernetes cluster created with the [cluster module](#cluster), preferably on a different terraform stack.
 
 ### Available variables:
 

--- a/base/main.tf
+++ b/base/main.tf
@@ -69,14 +69,14 @@ data "template_file" "helm_values" {
 
   vars {
     nginx_controller_image_version = "${var.nginx_controller_image_version}"
-    lego_email = "${var.lego_email}"
-    lego_url = "${var.lego_url}"
-    dex_github_client_id = "${var.dex_github_client_id}"
-    dex_github_client_secret = "${var.dex_github_client_secret}"
-    dex_github_org = "${var.dex_github_org}"
-    kubesignin_client_secret = "${var.kubesignin_client_secret}"
-    kubesignin_domain_name = "kubesignin.${var.name}"
-    external_dns_role_arn = "${aws_iam_role.external_dns_role.arn}"
+    lego_email                     = "${var.lego_email}"
+    lego_url                       = "${var.lego_url}"
+    dex_github_client_id           = "${var.dex_github_client_id}"
+    dex_github_client_secret       = "${var.dex_github_client_secret}"
+    dex_github_org                 = "${var.dex_github_org}"
+    kubesignin_client_secret       = "${var.kubesignin_client_secret}"
+    kubesignin_domain_name         = "kubesignin.${var.name}"
+    external_dns_role_arn          = "${aws_iam_role.external_dns_role.arn}"
   }
 }
 

--- a/base/main.tf
+++ b/base/main.tf
@@ -15,7 +15,7 @@ resource "aws_iam_role" "external_dns_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "AWS": "${data.terraform_remote_state.k8s-cluster.k8s_nodes_iam_role_arn}"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_nodes_iam_role_name}"
       },
       "Effect": "Allow"
     }

--- a/base/main.tf
+++ b/base/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = "> 0.9.4"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "external_dns_role" {
+  name = "${var.name}_external_dns_role"
+  path = "/kube2iam/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "${data.terraform_remote_state.k8s-cluster.k8s_nodes_iam_role_arn}"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "external_dns_role_policy" {
+  name = "${var.name}_external_dns_policy"
+  role = "${aws_iam_role.external_dns_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "route53:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "kube2iam_assume_role_policy" {
+  name = "${var.name}_kube2iam_assume_role_policy"
+  role = "${var.cluster_nodes_iam_role_name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/kube2iam/*"
+    }
+  ]
+}
+EOF
+}
+
+data "template_file" "helm_values" {
+  template = "${file("${path.module}/../templates/helm-values.tpl.yaml")}"
+
+  vars {
+    nginx_controller_image_version = "${var.nginx_controller_image_version}"
+    lego_email = "${var.lego_email}"
+    lego_url = "${var.lego_url}"
+    dex_github_client_id = "${var.dex_github_client_id}"
+    dex_github_client_secret = "${var.dex_github_client_secret}"
+    dex_github_org = "${var.dex_github_org}"
+    kubesignin_client_secret = "${var.kubesignin_client_secret}"
+    kubesignin_domain_name = "kubesignin.${var.name}"
+    external_dns_role_arn = "${aws_iam_role.external_dns_role.arn}"
+  }
+}
+
+resource "null_resource" "helm_values_file" {
+  provisioner "local-exec" {
+    command = <<-EOC
+      tee helm_values.yaml <<EOF
+      ${data.template_file.helm_values.rendered}
+      EOF
+      EOC
+  }
+}

--- a/base/outputs.tf
+++ b/base/outputs.tf
@@ -1,0 +1,7 @@
+output "external_dns_role_arn" {
+  value = "${aws_iam_role.external_dns_role.arn}"
+}
+
+output "external_dns_role_name" {
+  value = "${aws_iam_role.external_dns_role.name}"
+}

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -8,7 +8,7 @@ variable "cluster_nodes_iam_role_name" {
 
 variable "nginx_controller_image_version" {
   description = ""
-  default = "0.9.0-beta.7"
+  default     = "0.9.0-beta.7"
 }
 
 variable "lego_email" {
@@ -17,7 +17,7 @@ variable "lego_email" {
 
 variable "lego_url" {
   description = ""
-  default = "https://acme-v01.api.letsencrypt.org/directory"
+  default     = "https://acme-v01.api.letsencrypt.org/directory"
 }
 
 variable "dex_github_client_id" {

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  description = "Kubernetes Cluster Name"
+}
+
+variable "cluster_nodes_iam_role_name" {
+  description = "IAM role name for the k8s cluster worker nodes"
+}
+
+variable "nginx_controller_image_version" {
+  description = ""
+  default = "0.9.0-beta.7"
+}
+
+variable "lego_email" {
+  description = ""
+}
+
+variable "lego_url" {
+  description = ""
+  default = "https://acme-v01.api.letsencrypt.org/directory"
+}
+
+variable "dex_github_client_id" {
+  description = ""
+}
+
+variable "dex_github_client_secret" {
+  description = ""
+}
+
+variable "dex_github_org" {
+  description = ""
+}
+
+variable "kubesignin_client_secret" {
+  description = ""
+}

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -1,0 +1,37 @@
+# Nginx-ingress
+controller:
+  image:
+    tag: "${nginx_controller_image_version}"
+  publishService:
+    enabled: true
+  rbac:
+    enabled: true
+  stats:
+    enabled: true
+
+# Kube-lego
+config:
+  LEGO_EMAIL: ${lego_email}
+  LEGO_URL: ${lego_url}
+
+# Kube2iam
+host:
+  iptables: true
+  interface: cali+
+
+Dex:
+  Issuer: https://${kubesignin_domain_name}/dex
+  Connector:
+    GitHub:
+      Name: GitHub
+      ClientId: ${dex_github_client_id}
+      ClientSecret: ${dex_github_client_secret}
+      Org: ${dex_github_org}
+
+Kubesignin:
+  ClientSecret: "${kubesignin_client_secret}"
+  RedirectUri: https://${kubesignin_domain_name}/callback
+  DomainName: ${kubesignin_domain_name}
+
+ExternalDNS:
+  IAMRoleARN: ${external_dns_role_arn}


### PR DESCRIPTION
This terraform module generates a `helm-values.yaml` file to be used to install all the needed helm packages for a base setup of a k8s cluster. Much like the `cluster` module generates the kops config.

This module will also create the needed IAM roles and policies for `external-dns` and `kube2iam`