### PR TITLE
split prometheus-operator values to a different file

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -130,3 +130,21 @@ resource "null_resource" "helm_values_external_dns_file" {
       EOC
   }
 }
+
+data "template_file" "helm_values_prometheus_operator" {
+  template = "${file("${path.module}/../templates/helm-values-prometheus-operator.tpl.yaml")}"
+}
+
+resource "null_resource" "helm_values_prometheus_operator_file" {
+  triggers {
+    content = "${data.template_file.helm_values_prometheus_operator.rendered}"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOC
+      tee ${path.cwd}/helm-values-prometheus-operator.yaml <<EOF
+      ${data.template_file.helm_values_prometheus_operator.rendered}
+      EOF
+      EOC
+  }
+}

--- a/templates/helm-values-prometheus-operator.tpl.yaml
+++ b/templates/helm-values-prometheus-operator.tpl.yaml
@@ -1,0 +1,6 @@
+# enables rbac in multiple charts
+# rbac.create is the standard way to enable rbac
+
+image:
+  tag: v0.11.1
+sendAnalytics: false

--- a/templates/helm-values-prometheus-operator.tpl.yaml
+++ b/templates/helm-values-prometheus-operator.tpl.yaml
@@ -1,6 +1,3 @@
-# enables rbac in multiple charts
-# rbac.create is the standard way to enable rbac
-
 image:
   tag: v0.11.1
 sendAnalytics: false

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -37,12 +37,6 @@ Kubesignin:
   RedirectUri: https://${kubesignin_domain_name}/callback
   DomainName: ${kubesignin_domain_name}
 
-# Prometheus
-prometheus-operator:
-  image:
-    tag: v0.11.1
-  sendAnalytics: false
-
 kube-prometheus:
   alertmanager:
     image:


### PR DESCRIPTION
Because of chart changes the prometheus-operator values were no longer picked up.

This change splits those values to its own file so it doesn't interfere with other charts.