### PR TITLE
Enable proxy protocol and update nginx-ingress

### DIFF
--- a/base/variables.tf
+++ b/base/variables.tf
@@ -8,7 +8,7 @@ variable "cluster_nodes_iam_role_name" {
 
 variable "nginx_controller_image_version" {
   description = ""
-  default     = "0.9.0-beta.11"
+  default     = "0.9.0-beta.13"
 }
 
 variable "lego_email" {

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -11,6 +11,12 @@ controller:
     enabled: true
   stats:
     enabled: true
+  config:
+    use-proxy-protocol: "true"
+  replicaCount: 3
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
 
 # Kube-lego
 config:


### PR DESCRIPTION
We need proxy-protocol to be enabled to preserve the source IP
The source IP is use for whitelists of eg grafana and can be used
to debug network issues. without proxy-protocol all requests are
logged as localhost.