### PR TITLE
set crosssubnet option

### DIFF
--- a/templates/kops-cluster.tpl.yaml
+++ b/templates/kops-cluster.tpl.yaml
@@ -37,7 +37,8 @@ ${etcd_members_events}
   networkCIDR: ${vpc_cidr}
   networkID: ${vpc_id}
   networking:
-    calico: {}
+    calico:
+      crossSubnet: true
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0


### PR DESCRIPTION
`crossSubnet: true` will prevent ip-ip encapsulation when traffic stays inside the AZ.
It will also deploy a service to disable src-dst on aws

https://github.com/kubernetes/kops/blob/master/docs/networking.md#enable-cross-subnet-mode-in-calico-aws-only