### PR TITLE
update variable escaping in template

### DIFF
--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -177,7 +177,7 @@ kube-prometheus:
             }
             ANNOTATIONS {
               summary = "Targets are down",
-              description = "{{ \$$value }}% or more of {{ \$$labels.job }} targets are down."
+              description = "{{ $$value }}% or more of {{ $$labels.job }} targets are down."
             }
           ### Dead man's switch ###
           ALERT DeadMansSwitch
@@ -193,17 +193,17 @@ kube-prometheus:
           ALERT AlertmanagerConfigInconsistent
             IF   count_values by (service) ("config_hash", alertmanager_config_hash)
               / on(service) group_left
-                label_replace(prometheus_operator_alertmanager_spec_replicas, "service", "alertmanager-\$$1", "alertmanager", "(.*)") != 1
+                label_replace(prometheus_operator_alertmanager_spec_replicas, "service", "alertmanager-$$1", "alertmanager", "(.*)") != 1
             FOR 5m
             LABELS {
               severity = "critical"
             }
             ANNOTATIONS {
               summary = "Alertmanager configurations are inconsistent",
-              description = "The configuration of the instances of the Alertmanager cluster \`{{\$$labels.service}}\` are out of sync."
+              description = "The configuration of the instances of the Alertmanager cluster `{{$$labels.service}}` are out of sync."
             }
           ALERT AlertmanagerDownOrMissing
-            IF   label_replace(prometheus_operator_alertmanager_spec_replicas, "job", "alertmanager-\$$1", "alertmanager", "(.*)")
+            IF   label_replace(prometheus_operator_alertmanager_spec_replicas, "job", "alertmanager-$$1", "alertmanager", "(.*)")
               / on(job) group_right
                 sum by(job) (up) != 1
             FOR 5m
@@ -222,7 +222,7 @@ kube-prometheus:
             }
             ANNOTATIONS {
               summary = "Alertmanager configuration reload has failed",
-              description = "Reloading Alertmanager's configuration has failed for {{ \$$labels.namespace }}/{{ \$$labels.pod}}."
+              description = "Reloading Alertmanager's configuration has failed for {{ $$labels.namespace }}/{{ $$labels.pod}}."
             }
         prometheus.rules: |+
           ALERT FailedReload
@@ -233,7 +233,7 @@ kube-prometheus:
             }
             ANNOTATIONS {
               summary = "Prometheus configuration reload has failed",
-              description = "Reloading Prometheus' configuration has failed for {{ \$$labels.namespace }}/{{ \$$labels.pod}}."
+              description = "Reloading Prometheus' configuration has failed for {{ $$labels.namespace }}/{{ $$labels.pod}}."
             }
 
 grafana:


### PR DESCRIPTION
The old escaping rendered `\$$`. This PR updates the escape to correctly render the value.

Possible it broke because of switching to local_file?