### PR TITLE
restart kubelet every 10 minutes on the helm node

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -110,7 +110,7 @@ data template_file "worker-instancegroup-spec" {
 }
 
 data template_file "helm-instancegroup-spec" {
-  template = "${file("${path.module}/../templates/kops-instancegroup-worker.tpl.yaml")}"
+  template = "${file("${path.module}/../templates/kops-instancegroup-helm.tpl.yaml")}"
 
   vars {
     name               = "helm"

--- a/templates/kops-instancegroup-helm.tpl.yaml
+++ b/templates/kops-instancegroup-helm.tpl.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: ${cluster-name}
+  name: ${name}
+spec:
+  image: 496014204152/${kubernetes_ami}
+  machineType: ${instance_type}
+  maxSize: ${max}
+  minSize: ${min}
+  role: Node
+  subnets:
+${subnets}
+  cloudLabels:
+    role: worker
+    subnet: app
+    access: private
+  ${helm_node == true ? "nodeLabels:\n    function: helm" : ""}
+  taints:
+  - function=helm:NoSchedule
+  additionalUserData:
+  - name: teleport.sh
+    type: text/x-shellscript
+    content: |
+      ${teleport_bootstrap}
+  - name: teleport.txt
+    type: text/cloud-config
+    content: |
+      write_files:
+      ${teleport_config}
+      ${teleport_service}
+  hooks:
+  - name: restart-kubelet.service
+    manifest: |
+      [Unit]
+      Description=etcd2 backup service
+
+      [Service]
+      Type=oneshot
+
+      ExecStart=-/bin/systemctl restart kubelet.service
+
+      [Install]
+      WantedBy=multi-user.target
+  - name: etcd2-backup.timer
+    manifest: |
+      [Unit]
+      Description=etcd2-backup service timer
+
+      [Timer]
+      OnBootSec=2min
+      OnUnitActiveSec=10min
+
+      [Install]
+      WantedBy=timers.target

--- a/templates/kops-instancegroup-helm.tpl.yaml
+++ b/templates/kops-instancegroup-helm.tpl.yaml
@@ -35,7 +35,7 @@ ${subnets}
   - name: restart-kubelet.service
     manifest: |
       [Unit]
-      Description=etcd2 backup service
+      Description=restart-kubelet service
 
       [Service]
       Type=oneshot
@@ -44,10 +44,10 @@ ${subnets}
 
       [Install]
       WantedBy=multi-user.target
-  - name: etcd2-backup.timer
+  - name: restart-kubelet.timer
     manifest: |
       [Unit]
-      Description=etcd2-backup service timer
+      Description=restart-kubelet service timer
 
       [Timer]
       OnBootSec=2min


### PR DESCRIPTION
adds an additional service to restart the kubelet on helm nodes.

this will clear the memory leaks until we have an official fix.