### PR TITLE
Add ability to customize alertmanager routes and receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ This terraform module will add an IAM policy to the k8s cluster nodes roles to a
 * [`kibana_image_tag`]: String(optional): Image tag of the kibana image. (default: "6.0.0")
 * [`extra_grafana_datasoures`]: Map(optional): Extra Grafana datasource urls we want to add. Form is a map with name as key and url as value. (default: {})
 * [`extra_grafana_dashboards`]: String(optional): Extra Grafana dashboards. From is the map structure of HELM.
+* [`extra_alertmanager_routes`]: String(optional): Extra alertmanager routes. Yaml format. (default: "")
+* [`extra_alertmanager_receivers`]: String(optional): Extra alertmanager receivers. Yaml format. (default: "")
 ### Output
 
 * [`external_dns_role_arn`]: String: ARN of the IAM role created for external-dns
@@ -145,6 +147,29 @@ dex_gh_connectors = {
     teamName = "team2"
   }
 }
+```
+
+example of the `extra_alertmanager_routes`:
+```yaml
+extra_alertmanager_routes = <<EOF
+- match:
+    severity: warning
+  receiver: slack-runtime
+  routes:
+  - match:
+      group: persistence
+    receiver: slack-persistence
+EOF
+```
+
+example of the `extra_alertmanager_receivers`:
+```yaml
+extra_alertmanager_receivers = <<EOF
+- name: opsgenieproxy
+  webhook_configs:
+    - send_resolved: false
+      url: http://k8s-monitor-opsgenie-heartbeat-proxy/proxy
+EOF
 ```
 
 ## Usage

--- a/base/main.tf
+++ b/base/main.tf
@@ -150,6 +150,8 @@ data "template_file" "helm_values" {
     slack_webhook_url              = "${var.slack_webhook_url}"
     extra_grafana_datasoures       = "${local.extra_grafana_datasoures}"
     extra_grafana_dashboards       = "${local.extra_grafana_dashboards}"
+    extra_alertmanager_routes      = "${indent(8,var.extra_alertmanager_routes)}"
+    extra_alertmanager_receivers   = "${indent(8,var.extra_alertmanager_receivers)}"
   }
 }
 

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -151,3 +151,13 @@ variable "extra_grafana_dashboards" {
   description = "Extra Grafana dashboards we want to add."
   default     = ""
 }
+
+variable "extra_alertmanager_routes" {
+  description = "Extra alertmanager routes."
+  default     = ""
+}
+
+variable "extra_alertmanager_receivers" {
+  description = "Extra alertmanager receivers."
+  default     = ""
+}

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -62,6 +62,7 @@ kube-prometheus:
         - match:
             alertname: DeadMansSwitch
           receiver: opsgenieproxy
+        ${extra_alertmanager_routes}
           repeat_interval: 1s
           group_interval: 1s
           group_wait: 1s
@@ -83,6 +84,7 @@ kube-prometheus:
             - channel: '#circle_persistence'
               send_resolved: true
               username: ${customer}-${environment}
+        ${extra_alertmanager_receivers}
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
We need to be able to customize alertmanager so that customers can add custom routes and receivers for their usage. This adds an extra terraform variable where you can add custom routes and receivers.
I added this a string instead of a map variable because the yaml of a route and receiver can contain a lot of custom parameters and nesting.

I tested this on our test cluster:
```
  extra_alertmanager_routes = <<EOF
- match:
    severity: test
  receiver: slack-test
  routes:
  - match:
      group: test
    receiver: slack-route2
EOF
  extra_alertmanager_receivers = <<EOF
- name: test
  webhook_configs:
    - send_resolved: false
      url: http://test
EOF
```

output
```
kube-prometheus:
  alertmanager:
    image:
      tag: v0.9.1
    replicaCount: 3
    config:
      global:
        resolve_timeout: 5m
        slack_api_url: https://hooks.slack.com/services/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
      route:
        group_by: ['job']
        group_wait: 30s
        group_interval: 5m
        repeat_interval: 12h
        receiver: 'opsgenie'
        routes:
        - match:
            severity: warning
          receiver: slack-runtime
          routes:
          - match:
              group: persistence
            receiver: slack-persistence
        - match:
            alertname: DeadMansSwitch
          receiver: opsgenieproxy
        - match:
            severity: test
          receiver: slack-test
          routes:
          - match:
              group: test
            receiver: slack-route2

          repeat_interval: 1s
          group_interval: 1s
          group_wait: 1s
      receivers:
        - name: opsgenie
          opsgenie_configs:
            - api_key: '60d48f9c-c3a4-4298-8c79-852b30d814f5'
              tags: sla_test,kubernetes,client_skyscrapers
        - name: opsgenieproxy
          webhook_configs:
            - send_resolved: false
              url: http://k8s-monitor-opsgenie-heartbeat-proxy/proxy
        - name: slack-runtime
          slack_configs:
            - send_resolved: true
              username: skyscrapers-test
        - name: slack-persistence
          slack_configs:
            - channel: '#circle_persistence'
              send_resolved: true
              username: skyscrapers-test
        - name: test
          webhook_configs:
            - send_resolved: false
              url: http://test
```