### PR TITLE
adding option to set scale-down-utilization-threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This terraform module will add an IAM policy to the k8s cluster nodes roles to a
 * [`prometheus_groups`]: List(optional): Extra groups that will be granted access to the Prometheus dashboard. When using Dex and Kubesignin these will be GitHub teams in the form `<gh_org>:<gh_team>`, for example `skyscrapers:k8s-admins`. Empty by default. Note: `skyscrapers:k8s-admins` and `var.k8s_admins_groups` are always granted access.
 * [`kibana_groups`]: List(optional): Extra groups that will be granted access to the Kibana dashboard. When using Dex and Kubesignin these will be GitHub teams in the form `<gh_org>:<gh_team>`, for example `skyscrapers:k8s-admins`. Empty by default. Note: `skyscrapers:k8s-admins` and `var.k8s_admins_groups` are always granted access.
 * [`extra_oidc_proxies`]: String(optional): Extra OIDC proxies to setup."
+* [`utilization_threshold`]: String(optional): Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. (default 0.5)
 
 ### Output
 

--- a/base/iam.tf
+++ b/base/iam.tf
@@ -130,7 +130,6 @@ resource "aws_iam_role_policy" "kube2iam_assume_role_policy_masters" {
 EOF
 }
 
-
 ## Cluster-Autoscaler
 
 data "aws_iam_policy_document" "autoscaler_assume" {
@@ -138,12 +137,12 @@ data "aws_iam_policy_document" "autoscaler_assume" {
     effect = "Allow"
 
     actions = [
-      "sts:AssumeRole"
+      "sts:AssumeRole",
     ]
 
     principals {
-      type = "AWS"
-      identifiers= ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_masters_iam_role_name}"]
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_masters_iam_role_name}"]
     }
   }
 }

--- a/base/main.tf
+++ b/base/main.tf
@@ -223,9 +223,10 @@ data "template_file" "helm_values_autoscaler" {
   template = "${file("${path.module}/../templates/helm-values-autoscaler.tpl.yaml")}"
 
   vars {
-    aws_region          = "${data.aws_region.current.name}"
-    cluster_name        = "${var.name}"
-    autoscaler_role_arn = "${aws_iam_role.autoscaler.arn}"
+    aws_region            = "${data.aws_region.current.name}"
+    cluster_name          = "${var.name}"
+    autoscaler_role_arn   = "${aws_iam_role.autoscaler.arn}"
+    utilization_threshold = "${var.utilization_threshold}"
   }
 }
 

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -207,3 +207,8 @@ variable "customer_slack_hook" {
   description = "The slack webhook where customer alerts will be sent to"
   default     = ""
 }
+
+variable "utilization_threshold" {
+  description = "Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down"
+  default     = "0.5"
+}

--- a/templates/helm-values-autoscaler.tpl.yaml
+++ b/templates/helm-values-autoscaler.tpl.yaml
@@ -28,7 +28,7 @@ extraArgs:
   # scale-down-delay: 10m
   # scale-down-non-empty-candidates-count: 5
   # scale-down-unneeded-time: 10m
-  # scale-down-utilization-threshold: 0.5
+  scale-down-utilization-threshold: ${utilization_threshold}
   # skip-nodes-with-local-storage: false
   # skip-nodes-with-system-pods: true
 


### PR DESCRIPTION
This PR adds the option to set `scale-down-utilization-threshold` for the autoscaler charts.
This allows to tune autoscaling on a customer-specific basis
Low priority