### PR TITLE
allow changing the default dns provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Creates a full `kops` cluster specification yaml, including the required instanc
 * [`calico_logseverity`]: String(optional): Sets the logSeverityScreen setting for the Calico CNI. Defaults to `"warning"`
 * [`nat_gateway_ids`]: List(required): List of NAT gateway ids to associate to the route tables created by kops. There must be one NAT gateway for each availability zone in the region.
 * [`bastion_cidr`]: String(required): CIDR of the bastion host. This will be used to allow SSH access to kubernetes nodes
+* [`dns_provider`]: String(optional): Sets the DNS provider of the cluster to KubeDNS or CoreDNS. Defaults to KubeDNS
 
 ### Output
 

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -198,6 +198,7 @@ data template_file "cluster-spec" {
     system_reserved_memory = "${var.system_reserved_memory}"
     system_reserved_es     = "${var.system_reserved_es}"
     kubelet_eviction_hard  = "${var.kubelet_eviction_hard}"
+    dns_provider           = "${var.dns_provider}"
   }
 }
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -145,3 +145,8 @@ variable "kubelet_eviction_hard" {
   description = "Comma-delimited list of hard eviction expressions."
   default     = "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%"
 }
+
+variable "dns_provider" {
+  description = "DNS provider to use for the cluster."
+  default     = "KubeDNS"
+}

--- a/templates/kops-cluster.tpl.yaml
+++ b/templates/kops-cluster.tpl.yaml
@@ -66,3 +66,5 @@ ${utility_subnets}
       type: Public
     masters: private
     nodes: private
+  kubeDNS:
+    provider: ${dns_provider}


### PR DESCRIPTION
Adding option to change dns provider of the cluster, defaults to KubeDNS

Related issue: https://github.com/skyscrapers/engineering/issues/36